### PR TITLE
Add MCP health check and profile lookup helpers

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -42,6 +42,11 @@ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 PATCHRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm instal
 }
 ```
 
+On Windows, if your MCP client strips custom environment variables, the server
+also checks the current user's `HKCU\Environment` values for `SHARDX_API` and
+`SHARDX_TOKEN`. This keeps Codex/Cursor-style stdio launches working without
+copying the token into client config.
+
 ### HTTP mode (optional, self-hosted)
 
 If you'd rather host it yourself and connect by URL, run it with
@@ -63,6 +68,12 @@ MCP_HTTP_PORT=40326 SHARDX_API=http://127.0.0.1:40325 SHARDX_TOKEN=… node inde
 
 **API**
 
+- `health_check` → confirms the launcher is reachable and auth works
+- `find_profile_by_name(query, exact?, limit?)` → safe profile summaries only
+- `ensure_profile_started(profile_id? | profile_query?, exact?, headless?)`
+  → idempotently starts one resolved profile and returns its CDP endpoint
+- `safe_open_url(profile_id? | profile_query?, exact?, url, headless?)`
+  → starts one resolved profile, opens an `http(s)` URL, returns title/url
 - `list_profiles`, `get_profile`, `create_profile`, `create_temporary_profile`,
   `edit_profile`, `delete_profile`
 - `new_fingerprint(platform?)`
@@ -129,10 +140,12 @@ headless) if it isn't running; actions target the profile's *active* tab:
 
 ## Typical agent flow
 
-1. `create_profile` (or `create_temporary_profile`) — optionally with a `proxy`.
-2. `browser_navigate(profile_id, "https://…")` — starts the browser with
+1. `health_check` — fail fast when the launcher is closed or the token is stale.
+2. `find_profile_by_name` or `create_profile` / `create_temporary_profile`.
+3. `safe_open_url` for a one-shot smoke check, or
+   `browser_navigate(profile_id, "https://…")` — starts the browser with
    CDP and opens the page.
-3. `browser_evaluate` / `browser_screenshot` / `browser_click` / `browser_fill`.
+4. `browser_evaluate` / `browser_screenshot` / `browser_click` / `browser_fill`.
 
 ### Human input
 
@@ -163,4 +176,4 @@ where you want it.
 These calls take **real time** — `human_fill` returns when the last key is
 up, and reports how long the move and the typing took. Budget for it the
 way you would for a person.
-4. `stop_profile` when done (temporary profiles self-delete on close).
+5. `stop_profile` when done (temporary profiles self-delete on close).

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -166,15 +166,93 @@ const text = (v) => ({
   content: [{ type: "text", text: typeof v === "string" ? v : JSON.stringify(v, null, 2) }],
 });
 
+function profileSummary(profile, match) {
+  return {
+    id: profile.id,
+    name: profile.name,
+    folder: profile.folder,
+    notes: profile.notes,
+    running: !!profile.running,
+    cdp: profile.cdp,
+    ...(match ? { match } : {}),
+  };
+}
+
 const server = new McpServer({ name: "shardx", version: "0.1.0" });
 
 // ================= API tools =================
+
+server.tool(
+  "health_check",
+  "Check that the ShardX Launcher API is reachable and, when SHARDX_TOKEN is set, authenticated.",
+  {},
+  async () => {
+    const health = await api("/health");
+    if (!TOKEN) {
+      return text({
+        ok: false,
+        api: API,
+        launcher: health,
+        token_present: false,
+        authenticated: false,
+      });
+    }
+    try {
+      const [profiles, running] = await Promise.all([api("/profiles"), api("/running")]);
+      return text({
+        ok: true,
+        api: API,
+        launcher: health,
+        token_present: true,
+        authenticated: true,
+        profiles_count: profiles.length,
+        running_count: running.length,
+      });
+    } catch (error) {
+      return text({
+        ok: false,
+        api: API,
+        launcher: health,
+        token_present: true,
+        authenticated: false,
+        error: String(error?.message || error),
+      });
+    }
+  },
+);
 
 server.tool(
   "list_profiles",
   "List persistent profiles with their running state and CDP endpoint.",
   {},
   async () => text(await api("/profiles")),
+);
+
+server.tool(
+  "find_profile_by_name",
+  "Find profiles by id or profile name. Returns safe profile summaries, not full fingerprint config.",
+  {
+    query: z.string(),
+    exact: z.boolean().optional(),
+    limit: z.number().int().positive().max(50).optional(),
+  },
+  async ({ query, exact, limit }) => {
+    const q = query.trim().toLowerCase();
+    if (!q) return text([]);
+    const profiles = await api("/profiles");
+    const matches = [];
+    for (const profile of profiles) {
+      const id = String(profile.id || "");
+      const name = String(profile.name || "");
+      const lower = name.toLowerCase();
+      let match = null;
+      if (id === query) match = "id";
+      else if (exact ? lower === q : lower.includes(q)) match = exact ? "name_exact" : "name";
+      if (match) matches.push(profileSummary(profile, match));
+      if (matches.length >= (limit || 10)) break;
+    }
+    return text(matches);
+  },
 );
 
 server.tool(

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -13,11 +13,28 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { execFileSync } from "node:child_process";
 import { z } from "zod";
 import { chromium } from "patchright";
 
-const API = (process.env.SHARDX_API || "http://127.0.0.1:40325").replace(/\/+$/, "");
-const TOKEN = process.env.SHARDX_TOKEN || "";
+function readWindowsUserEnv(name) {
+  if (process.platform !== "win32") return "";
+  try {
+    const out = execFileSync("reg", ["query", "HKCU\\Environment", "/v", name], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    const line = out.split(/\r?\n/).find((l) => l.trim().startsWith(name));
+    return line?.trim().split(/\s{2,}/).slice(2).join(" ").trim() || "";
+  } catch {
+    return "";
+  }
+}
+
+const env = (name) => process.env[name] || readWindowsUserEnv(name);
+const API = (env("SHARDX_API") || "http://127.0.0.1:40325").replace(/\/+$/, "");
+const TOKEN = env("SHARDX_TOKEN") || "";
 
 // ---------- HTTP API helper ----------
 
@@ -178,6 +195,45 @@ function profileSummary(profile, match) {
   };
 }
 
+function matchProfile(profile, query, exact = false) {
+  const q = query.trim().toLowerCase();
+  if (!q) return null;
+  const id = String(profile.id || "");
+  const name = String(profile.name || "");
+  const lower = name.toLowerCase();
+  if (id === query) return "id";
+  if (exact ? lower === q : lower.includes(q)) return exact ? "name_exact" : "name";
+  return null;
+}
+
+async function findProfiles(query, { exact = false, limit = 10 } = {}) {
+  const profiles = await api("/profiles");
+  const matches = [];
+  for (const profile of profiles) {
+    const match = matchProfile(profile, query, exact);
+    if (match) matches.push(profileSummary(profile, match));
+    if (matches.length >= limit) break;
+  }
+  return matches;
+}
+
+async function resolveProfile({ profile_id, profile_query, exact = false }) {
+  if (profile_id) return { id: profile_id, match: "id" };
+  const matches = await findProfiles(profile_query || "", { exact, limit: 2 });
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly 1 profile match, got ${matches.length}`);
+  }
+  return matches[0];
+}
+
+function assertHttpUrl(url) {
+  const parsed = new URL(url);
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("safe_open_url only supports http(s) URLs");
+  }
+  return parsed.href;
+}
+
 const server = new McpServer({ name: "shardx", version: "0.1.0" });
 
 // ================= API tools =================
@@ -236,22 +292,54 @@ server.tool(
     exact: z.boolean().optional(),
     limit: z.number().int().positive().max(50).optional(),
   },
-  async ({ query, exact, limit }) => {
-    const q = query.trim().toLowerCase();
-    if (!q) return text([]);
-    const profiles = await api("/profiles");
-    const matches = [];
-    for (const profile of profiles) {
-      const id = String(profile.id || "");
-      const name = String(profile.name || "");
-      const lower = name.toLowerCase();
-      let match = null;
-      if (id === query) match = "id";
-      else if (exact ? lower === q : lower.includes(q)) match = exact ? "name_exact" : "name";
-      if (match) matches.push(profileSummary(profile, match));
-      if (matches.length >= (limit || 10)) break;
+  async ({ query, exact, limit }) =>
+    text(await findProfiles(query, { exact: !!exact, limit: limit || 10 })),
+);
+
+server.tool(
+  "ensure_profile_started",
+  "Start a profile only if needed and return its CDP endpoint. Accepts a profile id or a unique profile name/query.",
+  {
+    profile_id: z.string().optional(),
+    profile_query: z.string().optional(),
+    exact: z.boolean().optional(),
+    headless: z.boolean().optional(),
+  },
+  async ({ profile_id, profile_query, exact, headless }) => {
+    const profile = await resolveProfile({ profile_id, profile_query, exact });
+    const running = await api("/running");
+    let entry = running.find((r) => r.profile_id === profile.id);
+    if (!entry?.cdp) {
+      const started = await api(`/profiles/${profile.id}/start`, {
+        method: "POST",
+        body: { headless: !!headless },
+      });
+      entry = { profile_id: profile.id, cdp: started.cdp, started: true };
     }
-    return text(matches);
+    return text({
+      profile: profileSummary(profile),
+      running: true,
+      started: !!entry.started,
+      cdp: entry.cdp,
+    });
+  },
+);
+
+server.tool(
+  "safe_open_url",
+  "Resolve/start a profile, open an http(s) URL, wait for DOM content, and return title/url.",
+  {
+    profile_id: z.string().optional(),
+    profile_query: z.string().optional(),
+    exact: z.boolean().optional(),
+    url: z.string(),
+    headless: z.boolean().optional(),
+  },
+  async ({ profile_id, profile_query, exact, url, headless }) => {
+    const profile = await resolveProfile({ profile_id, profile_query, exact });
+    const page = await pageFor(profile.id, { headless: !!headless });
+    await page.goto(assertHttpUrl(url), { waitUntil: "domcontentloaded", timeout: 60000 });
+    return text({ profile: profileSummary(profile), url: page.url(), title: await page.title() });
   },
 );
 


### PR DESCRIPTION
## Summary
- add `health_check` for ShardX Launcher API reachability/auth checks
- add `find_profile_by_name` to locate profiles by id/name without returning full fingerprint config
- add `ensure_profile_started` to idempotently resolve/start a profile and return its CDP endpoint
- add `safe_open_url` to resolve/start a profile, open an `http(s)` URL, and return title/url for MCP smoke checks
- let the MCP server read `SHARDX_API` / `SHARDX_TOKEN` from Windows user environment when stdio clients strip custom env vars
- document the Codex/Cursor-friendly setup and helper flow

## Why
These helpers make MCP clients safer to bootstrap and automate against ShardX Launcher:
- clients can detect whether the launcher is reachable and whether `SHARDX_TOKEN` is valid before mutating calls
- clients can resolve human-friendly profile names without inspecting full profile objects
- agents can do a one-shot profile-start + page-open smoke test without manually chaining low-level tools
- Windows stdio clients that whitelist inherited env vars can still use the user-level token without copying secrets into client config

This PR intentionally does not change browser engine behavior, fingerprint behavior, profile isolation, or the launcher API contract.

## Test
- `node --check mcp/index.js`
- local MCP smoke test against ShardX Launcher v0.1.10:
  - `health_check` authenticated with token from Windows user env fallback
  - `find_profile_by_name` found `VN Automation 001 - No Proxy`
  - `ensure_profile_started` returned an existing CDP endpoint
  - `safe_open_url` opened `https://example.com/` and returned `Example Domain`
  - `safe_open_url` rejected `file://...` with `safe_open_url only supports http(s) URLs`
