### PR TITLE
Improve MCP setup guidance in Settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shardx-launcher",
-  "version": "0.1.5",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shardx-launcher",
-      "version": "0.1.5",
+      "version": "0.1.11",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shardx-launcher",
   "private": true,
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "shardx-launcher"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shardx-launcher"
-version = "0.1.10"
+version = "0.1.11"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/launch.rs
+++ b/src-tauri/src/launch.rs
@@ -200,7 +200,6 @@ pub async fn launch_profile(
     cmd.stdout(Stdio::null()).stderr(Stdio::null());
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
         // 0x08000000 = CREATE_NO_WINDOW — suppress the brief console flash
         // when a Tauri GUI app spawns the engine binary.
         cmd.creation_flags(0x08000000);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,10 +48,38 @@ pub fn notify_store_changed(kind: &str) {
 /// Download MCP server source into `<dir>/mcp`; user manages registration.
 #[tauri::command]
 async fn mcp_download(dir: String) -> Result<String, String> {
-    mcp_setup::download_mcp(std::path::Path::new(&dir))
+    let path = mcp_setup::download_mcp(std::path::Path::new(&dir))
         .await
-        .map(|p| p.display().to_string())
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    let path_string = path.display().to_string();
+    let mut s = settings::load().map_err(|e| e.to_string())?;
+    s.mcp_path = Some(path_string.clone());
+    settings::save(&s).map_err(|e| e.to_string())?;
+    notify_store_changed("settings");
+    Ok(path_string)
+}
+
+#[tauri::command]
+fn mcp_status() -> Result<Value, String> {
+    let s = settings::load().map_err(|e| e.to_string())?;
+    Ok(match s.mcp_path {
+        Some(path) => {
+            let dir = std::path::Path::new(&path);
+            let installed = dir.join("index.js").is_file() && dir.join("package.json").is_file();
+            serde_json::json!({
+                "path": path,
+                "installed": installed,
+                "state": if installed { "ready" } else { "missing" },
+                "message": if installed { "MCP server files are downloaded." } else { "Saved MCP folder is missing index.js or package.json." },
+            })
+        }
+        None => serde_json::json!({
+            "path": null,
+            "installed": false,
+            "state": "not_downloaded",
+            "message": "MCP server has not been downloaded yet.",
+        }),
+    })
 }
 
 // ---- Profiles ----
@@ -1203,6 +1231,7 @@ pub fn run() {
             cookies_export_to_file,
             cookies_import,
             mcp_download,
+            mcp_status,
             runtime::runtime_status,
             runtime::runtime_install,
             runtime::launcher_update_check,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -61,18 +61,38 @@ async fn mcp_download(dir: String) -> Result<String, String> {
 
 #[tauri::command]
 fn mcp_status() -> Result<Value, String> {
-    let s = settings::load().map_err(|e| e.to_string())?;
-    Ok(match s.mcp_path {
-        Some(path) => {
-            let dir = std::path::Path::new(&path);
-            let installed = dir.join("index.js").is_file() && dir.join("package.json").is_file();
-            serde_json::json!({
+    let mut s = settings::load().map_err(|e| e.to_string())?;
+    if let Some(path) = &s.mcp_path {
+        let installed = mcp_setup::is_mcp_dir(std::path::Path::new(path));
+        if installed {
+            return Ok(serde_json::json!({
                 "path": path,
-                "installed": installed,
-                "state": if installed { "ready" } else { "missing" },
-                "message": if installed { "MCP server files are downloaded." } else { "Saved MCP folder is missing index.js or package.json." },
-            })
+                "installed": true,
+                "state": "ready",
+                "message": "MCP server files are downloaded.",
+            }));
         }
+    }
+
+    if let Some(path) = mcp_setup::find_existing_mcp() {
+        let path = path.display().to_string();
+        s.mcp_path = Some(path.clone());
+        settings::save(&s).map_err(|e| e.to_string())?;
+        return Ok(serde_json::json!({
+            "path": path,
+            "installed": true,
+            "state": "ready",
+            "message": "Found existing MCP server files from a previous download.",
+        }));
+    }
+
+    Ok(match s.mcp_path {
+        Some(path) => serde_json::json!({
+            "path": path,
+            "installed": false,
+            "state": "missing",
+            "message": "Saved MCP folder is missing index.js or package.json.",
+        }),
         None => serde_json::json!({
             "path": null,
             "installed": false,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,23 @@ async fn mcp_download(dir: String) -> Result<String, String> {
 }
 
 #[tauri::command]
+fn mcp_set_path(dir: String) -> Result<Value, String> {
+    let path = mcp_setup::resolve_mcp_dir(std::path::Path::new(&dir))
+        .ok_or_else(|| "Selected folder is not a ShardX MCP server folder.".to_string())?;
+    let path = path.display().to_string();
+    let mut s = settings::load().map_err(|e| e.to_string())?;
+    s.mcp_path = Some(path.clone());
+    settings::save(&s).map_err(|e| e.to_string())?;
+    notify_store_changed("settings");
+    Ok(serde_json::json!({
+        "path": path,
+        "installed": true,
+        "state": "ready",
+        "message": "Using existing MCP server files.",
+    }))
+}
+
+#[tauri::command]
 fn mcp_status() -> Result<Value, String> {
     let mut s = settings::load().map_err(|e| e.to_string())?;
     if let Some(path) = &s.mcp_path {
@@ -1251,6 +1268,7 @@ pub fn run() {
             cookies_export_to_file,
             cookies_import,
             mcp_download,
+            mcp_set_path,
             mcp_status,
             runtime::runtime_status,
             runtime::runtime_install,

--- a/src-tauri/src/mcp_setup.rs
+++ b/src-tauri/src/mcp_setup.rs
@@ -19,9 +19,22 @@ const MCP_ARCHIVE_URL: &str =
 /// Top-level directory inside the tarball that wraps the actual files.
 const MCP_TOP_DIR: &str = "ShardX-MCP";
 
+fn download_destination(dir: &Path) -> PathBuf {
+    // The picker text says "choose a folder" while the status box shows the
+    // actual `mcp` folder. If the user repairs by selecting that shown folder,
+    // update it in place instead of creating `mcp/mcp`.
+    if is_mcp_dir(dir) || dir.file_name().is_some_and(|name| name == "mcp") {
+        dir.to_path_buf()
+    } else {
+        dir.join("mcp")
+    }
+}
+
 /// Download the MCP server into `<dir>/mcp` and return that path.
+///
+/// If `<dir>` already is the MCP folder, repair/update it in place.
 pub async fn download_mcp(dir: &Path) -> Result<PathBuf> {
-    let dest = dir.join("mcp");
+    let dest = download_destination(dir);
     let bytes = reqwest::get(MCP_ARCHIVE_URL)
         .await
         .context("download MCP archive")?
@@ -104,7 +117,7 @@ pub fn find_existing_mcp() -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::is_mcp_dir;
+    use super::{download_destination, is_mcp_dir};
 
     #[test]
     fn detects_downloaded_mcp_folder() {
@@ -118,5 +131,28 @@ mod tests {
         assert_eq!(super::resolve_mcp_dir(&dir).as_deref(), Some(dir.as_path()));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn download_destination_avoids_nested_mcp_when_repairing() {
+        let base = std::env::temp_dir().join(format!(
+            "shardx-mcp-destination-test-{}",
+            std::process::id()
+        ));
+        let normal_parent = base.join("ShardBrowser");
+        let existing_mcp = normal_parent.join("mcp");
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&existing_mcp).unwrap();
+        std::fs::write(existing_mcp.join("index.js"), "").unwrap();
+        std::fs::write(
+            existing_mcp.join("package.json"),
+            r#"{ "name": "shardx-mcp" }"#,
+        )
+        .unwrap();
+
+        assert_eq!(download_destination(&normal_parent), existing_mcp);
+        assert_eq!(download_destination(&existing_mcp), existing_mcp);
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src-tauri/src/mcp_setup.rs
+++ b/src-tauri/src/mcp_setup.rs
@@ -74,6 +74,14 @@ pub fn is_mcp_dir(dir: &Path) -> bool {
         .unwrap_or(false)
 }
 
+pub fn resolve_mcp_dir(dir: &Path) -> Option<PathBuf> {
+    if is_mcp_dir(dir) {
+        return Some(dir.to_path_buf());
+    }
+    let nested = dir.join("mcp");
+    is_mcp_dir(&nested).then_some(nested)
+}
+
 pub fn find_existing_mcp() -> Option<PathBuf> {
     let mut candidates = Vec::new();
     if let Some(dir) = dirs::document_dir() {
@@ -91,7 +99,7 @@ pub fn find_existing_mcp() -> Option<PathBuf> {
     if let Some(dir) = dirs::desktop_dir() {
         candidates.push(dir.join("mcp"));
     }
-    candidates.into_iter().find(|p| is_mcp_dir(p))
+    candidates.into_iter().find_map(|p| resolve_mcp_dir(&p))
 }
 
 #[cfg(test)]
@@ -107,6 +115,7 @@ mod tests {
         std::fs::write(dir.join("package.json"), r#"{ "name": "shardx-mcp" }"#).unwrap();
 
         assert!(is_mcp_dir(&dir));
+        assert_eq!(super::resolve_mcp_dir(&dir).as_deref(), Some(dir.as_path()));
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/mcp_setup.rs
+++ b/src-tauri/src/mcp_setup.rs
@@ -64,3 +64,50 @@ pub async fn download_mcp(dir: &Path) -> Result<PathBuf> {
     }
     Ok(dest)
 }
+
+pub fn is_mcp_dir(dir: &Path) -> bool {
+    if !dir.join("index.js").is_file() || !dir.join("package.json").is_file() {
+        return false;
+    }
+    std::fs::read_to_string(dir.join("package.json"))
+        .map(|s| s.contains("\"shardx-mcp\""))
+        .unwrap_or(false)
+}
+
+pub fn find_existing_mcp() -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(dir) = dirs::document_dir() {
+        candidates.extend([
+            dir.join("MCP").join("ShardBrowser").join("mcp"),
+            dir.join("MCP").join("mcp"),
+            dir.join("ShardBrowser").join("mcp"),
+            dir.join("GitHub").join("ShardBrowser").join("mcp"),
+            dir.join("mcp"),
+        ]);
+    }
+    if let Some(dir) = dirs::download_dir() {
+        candidates.push(dir.join("mcp"));
+    }
+    if let Some(dir) = dirs::desktop_dir() {
+        candidates.push(dir.join("mcp"));
+    }
+    candidates.into_iter().find(|p| is_mcp_dir(p))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_mcp_dir;
+
+    #[test]
+    fn detects_downloaded_mcp_folder() {
+        let dir = std::env::temp_dir().join(format!("shardx-mcp-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("index.js"), "").unwrap();
+        std::fs::write(dir.join("package.json"), r#"{ "name": "shardx-mcp" }"#).unwrap();
+
+        assert!(is_mcp_dir(&dir));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -33,6 +33,9 @@ pub struct Settings {
     /// (see `ensure_secret`); rotating it invalidates issued tokens.
     #[serde(default)]
     pub api_secret: String,
+    /// Last downloaded MCP server folder, if any.
+    #[serde(default)]
+    pub mcp_path: Option<String>,
 }
 
 fn default_theme() -> String {
@@ -63,6 +66,7 @@ pub fn load() -> Result<Settings> {
             api_enabled: default_api_enabled(),
             api_port: default_api_port(),
             api_secret: String::new(),
+            mcp_path: None,
         });
     }
     let body = fs::read_to_string(&path)?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ShardX Launcher",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "identifier": "com.shardx.launcher",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.css
+++ b/src/App.css
@@ -337,6 +337,7 @@ textarea { resize: vertical; min-height: 60px; line-height: 1.5; }
 .version-pill .shard-mini           { color: var(--accent); flex: 0 0 auto; }
 .version-pill-text                  { display: flex; flex-direction: column; min-width: 0; }
 .version-pill-current               { font-size: 12px; font-weight: 500; }
+.version-pill-label                 { color: var(--accent); font-size: 10.5px; font-weight: 600; }
 .version-pill-sub                   { font-size: 10.5px; color: var(--tx-4); }
 
 .version-pill.update-available {

--- a/src/App.css
+++ b/src/App.css
@@ -282,6 +282,11 @@ textarea { resize: vertical; min-height: 60px; line-height: 1.5; }
 }
 .side-auto-btn:hover { border-color: var(--accent); }
 .side-auto-btn:disabled { opacity: .5; cursor: default; }
+.side-auto-btn-ok {
+  background: #4ade8014;
+  color: var(--ok);
+}
+.side-auto-btn-ok:hover { border-color: #4ade8055; }
 
 /* Theme switch — a 2-segment pill (Light | Dark) sitting just above
    the user pill.  The active half gets the accent fill; clicking
@@ -1126,6 +1131,24 @@ textarea { resize: vertical; min-height: 60px; line-height: 1.5; }
   line-height: 1.5;
 }
 .settings-steps code { color: var(--tx-1); }
+.mcp-status {
+  margin-top: 10px;
+  padding: 9px 10px;
+  border: 1px solid var(--bd-1);
+  border-radius: var(--radius);
+  background: var(--bg-2);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 12px;
+}
+.mcp-status strong { color: var(--tx-1); white-space: nowrap; }
+.mcp-status span { color: var(--tx-3); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mcp-status-ready { border-color: #4ade8033; }
+.mcp-status-ready strong { color: var(--ok); }
+.mcp-status-missing { border-color: #f59e0b55; }
+.mcp-status-missing strong { color: #fbbf24; }
 .mcp-setup-box {
   margin-top: 10px;
   padding: 10px;

--- a/src/App.css
+++ b/src/App.css
@@ -1118,6 +1118,26 @@ textarea { resize: vertical; min-height: 60px; line-height: 1.5; }
 }
 .copy-icon:hover { color: var(--tx-1); background: var(--bg-1); }
 
+.settings-steps {
+  margin: 10px 0 12px;
+  padding-left: 20px;
+  color: var(--tx-2);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.settings-steps code { color: var(--tx-1); }
+.mcp-setup-box {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid var(--bd-1);
+  border-radius: var(--radius);
+  background: var(--bg-2);
+}
+.mcp-setup-actions {
+  margin-top: 10px;
+  flex-wrap: wrap;
+}
+
 /* Confirm modal */
 .dialog-confirm { max-width: 440px; }
 .confirm-msg { color: var(--tx-2); font-size: 13px; line-height: 1.5; margin: 0; }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4901,8 +4901,7 @@ function SettingsView() {
         <p className="muted small">
           Download the <strong>MCP</strong> server source (lets an AI client drive
           profiles and a CDP browser) into a folder you choose. The app does not run
-          it — install its deps and register it with your MCP client per the included
-          README. Requires Node.js.
+          it — install deps, set SHARDX_TOKEN in your user environment, restart your MCP client, then register it. Requires Node.js.
         </p>
         <div className={`mcp-status mcp-status-${mcpStatus?.state ?? "unknown"}`}>
           <strong>
@@ -4913,7 +4912,7 @@ function SettingsView() {
         <ol className="settings-steps">
           <li>{mcpReady ? "MCP files are already downloaded." : "Download the server once."}</li>
           <li>Run <code>npm install</code> inside the downloaded folder.</li>
-          <li>Register <code>index.js</code> with your MCP client and keep the token in <code>SHARDX_TOKEN</code>.</li>
+          <li>Set <code>SHARDX_TOKEN</code> in your user environment, restart your MCP client, then register <code>index.js</code>.</li>
         </ol>
         {!mcpReady && (
           <button className="btn-ghost" onClick={downloadMcp} disabled={mcpBusy}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ function detectHostOs(): "macOS" | "Windows" | "Linux" {
   return "macOS";
 }
 const HOST_OS = detectHostOs();
+const CUSTOM_BUILD_LABEL = "custom build";
 
 // OS clipboard via Tauri plugin (webview navigator.clipboard throws).
 const clip = {
@@ -3693,7 +3694,7 @@ function VersionPill() {
       <ShardMini />
       <div className="version-pill-text">
         <div className="version-pill-current">
-          ShardX Launcher v{info?.current ?? "…"}
+          ShardX Launcher v{info?.current ?? "…"} <span className="version-pill-label">{CUSTOM_BUILD_LABEL}</span>
         </div>
         <div className="version-pill-sub">
           {info === null

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4747,6 +4747,7 @@ function SettingsView() {
   };
 
   const [mcpBusy, setMcpBusy] = useState(false);
+  const [mcpPath, setMcpPath] = useState("");
   // Download MCP server source; user manages install + client setup.
   const downloadMcp = async () => {
     const dir = await open({ directory: true, title: "Where to download the MCP server" });
@@ -4754,9 +4755,37 @@ function SettingsView() {
     setMcpBusy(true);
     try {
       const path = await invoke<string>("mcp_download", { dir });
+      setMcpPath(path);
       toast.ok(`MCP downloaded to ${path}`);
     } catch (e) { toast.err("MCP download failed: " + String(e)); }
     finally { setMcpBusy(false); }
+  };
+  const mcpIndexPath = (dir: string) => {
+    const clean = dir.replace(/[\\/]+$/, "");
+    return `${clean}${clean.includes("\\") ? "\\" : "/"}index.js`;
+  };
+  const copyMcpInstall = async () => {
+    if (!mcpPath) return;
+    try {
+      await clip.write(`cd '${mcpPath.replace(/'/g, "''")}'; npm install`);
+      toast.ok("Copied MCP install command");
+    } catch (e) { toast.err(String(e)); }
+  };
+  const copyMcpConfig = async () => {
+    if (!mcpPath) return;
+    const snippet = {
+      mcpServers: {
+        shardx: {
+          command: "node",
+          args: [mcpIndexPath(mcpPath)],
+          env: { SHARDX_API: api?.base_url ?? "http://127.0.0.1:40325" },
+        },
+      },
+    };
+    try {
+      await clip.write(JSON.stringify(snippet, null, 2));
+      toast.ok("Copied MCP config snippet");
+    } catch (e) { toast.err(String(e)); }
   };
   const save = async () => {
     try { await invoke("settings_save", { value: s }); toast.ok("Settings saved"); }
@@ -4860,9 +4889,29 @@ function SettingsView() {
           it — install its deps and register it with your MCP client per the included
           README. Requires Node.js.
         </p>
+        <ol className="settings-steps">
+          <li>Download the server.</li>
+          <li>Run <code>npm install</code> inside the downloaded folder.</li>
+          <li>Register <code>index.js</code> with your MCP client and keep the token in <code>SHARDX_TOKEN</code>.</li>
+        </ol>
         <button className="btn-ghost" onClick={downloadMcp} disabled={mcpBusy}>
           <Icon.Download /> {mcpBusy ? "Downloading…" : "Download MCP server"}
         </button>
+        {mcpPath && (
+          <div className="mcp-setup-box">
+            <label>
+              <span className="lbl">Downloaded folder</span>
+              <CopyField value={mcpPath} />
+            </label>
+            <div className="row-inline mcp-setup-actions">
+              <button className="btn-ghost btn-sm" onClick={() => openPath(mcpPath).catch((e) => toast.err(String(e)))}>
+                Open folder
+              </button>
+              <button className="btn-ghost btn-sm" onClick={copyMcpInstall}>Copy install command</button>
+              <button className="btn-ghost btn-sm" onClick={copyMcpConfig}>Copy MCP config</button>
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="card-actions">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -280,12 +280,19 @@ type Settings = {
   api_enabled?: boolean;
   api_port?: number;
   api_secret?: string;
+  mcp_path?: string | null;
 };
 type ApiInfo = {
   enabled: boolean;
   port: number;
   base_url: string;
   token: string;
+};
+type McpStatus = {
+  path: string | null;
+  installed: boolean;
+  state: "not_downloaded" | "ready" | "missing";
+  message: string;
 };
 type Section = "browsers" | "proxies" | "proxyshard" | "fingerprints" | "settings";
 
@@ -701,22 +708,15 @@ function Sidebar({
 
   // Automation/MCP quick widget (fills the sidebar's lower space).
   const [autoUrl, setAutoUrl] = useState("");
-  const [mcpBusy, setMcpBusy] = useState(false);
+  const [mcp, setMcp] = useState<McpStatus | null>(null);
+  const refreshMcp = () => invoke<McpStatus>("mcp_status").then(setMcp).catch(() => {});
   useEffect(() => {
     invoke<{ base_url: string; enabled: boolean }>("api_info")
       .then((i) => setAutoUrl(i.enabled ? i.base_url : ""))
       .catch(() => {});
+    refreshMcp();
   }, []);
-  const downloadMcp = async () => {
-    const dir = await open({ directory: true, title: "Where to download the MCP server" });
-    if (typeof dir !== "string") return;
-    setMcpBusy(true);
-    try {
-      const p = await invoke<string>("mcp_download", { dir });
-      toast.ok(`MCP downloaded to ${p}`);
-    } catch (e) { toast.err("MCP download failed: " + String(e)); }
-    finally { setMcpBusy(false); }
-  };
+  useStoreChanged(refreshMcp);
 
   return (
     <aside className="sidebar">
@@ -757,8 +757,12 @@ function Sidebar({
           ) : (
             <div className="side-auto-off">API off — enable in Settings</div>
           )}
-          <button className="side-auto-btn" onClick={downloadMcp} disabled={mcpBusy}>
-            <Icon.Download /> {mcpBusy ? "Downloading…" : "Download MCP"}
+          <button
+            className={`side-auto-btn ${mcp?.installed ? "side-auto-btn-ok" : ""}`}
+            onClick={() => onSelect("settings")}
+            title={mcp?.message ?? "Set up MCP server in Settings"}
+          >
+            {mcp?.installed ? "✓" : <Icon.Download />} {mcp?.installed ? "MCP downloaded" : "Set up MCP"}
           </button>
           <button
             className="side-auto-btn"
@@ -4748,6 +4752,13 @@ function SettingsView() {
 
   const [mcpBusy, setMcpBusy] = useState(false);
   const [mcpPath, setMcpPath] = useState("");
+  const [mcpStatus, setMcpStatus] = useState<McpStatus | null>(null);
+  const applyMcpStatus = (status: McpStatus) => {
+    setMcpStatus(status);
+    setMcpPath(status.path ?? "");
+  };
+  const refreshMcp = () => invoke<McpStatus>("mcp_status").then(applyMcpStatus).catch(() => {});
+  useEffect(() => { refreshMcp(); }, []);
   // Download MCP server source; user manages install + client setup.
   const downloadMcp = async () => {
     const dir = await open({ directory: true, title: "Where to download the MCP server" });
@@ -4756,6 +4767,8 @@ function SettingsView() {
     try {
       const path = await invoke<string>("mcp_download", { dir });
       setMcpPath(path);
+      setS((cur) => ({ ...cur, mcp_path: path }));
+      await refreshMcp();
       toast.ok(`MCP downloaded to ${path}`);
     } catch (e) { toast.err("MCP download failed: " + String(e)); }
     finally { setMcpBusy(false); }
@@ -4791,6 +4804,8 @@ function SettingsView() {
     try { await invoke("settings_save", { value: s }); toast.ok("Settings saved"); }
     catch (e) { toast.err(String(e)); }
   };
+  const mcpReady = !!mcpStatus?.installed;
+  const mcpMissing = mcpStatus?.state === "missing";
   return (
     <section className="page settings-page">
       <Topbar crumbs={["System", "Settings"]} search="" onSearch={() => {}} />
@@ -4889,15 +4904,23 @@ function SettingsView() {
           it — install its deps and register it with your MCP client per the included
           README. Requires Node.js.
         </p>
+        <div className={`mcp-status mcp-status-${mcpStatus?.state ?? "unknown"}`}>
+          <strong>
+            {mcpReady ? "MCP server downloaded" : mcpMissing ? "MCP folder missing" : "MCP server not downloaded"}
+          </strong>
+          <span>{mcpStatus?.message ?? "Checking MCP status…"}</span>
+        </div>
         <ol className="settings-steps">
-          <li>Download the server.</li>
+          <li>{mcpReady ? "MCP files are already downloaded." : "Download the server once."}</li>
           <li>Run <code>npm install</code> inside the downloaded folder.</li>
           <li>Register <code>index.js</code> with your MCP client and keep the token in <code>SHARDX_TOKEN</code>.</li>
         </ol>
-        <button className="btn-ghost" onClick={downloadMcp} disabled={mcpBusy}>
-          <Icon.Download /> {mcpBusy ? "Downloading…" : "Download MCP server"}
-        </button>
-        {mcpPath && (
+        {!mcpReady && (
+          <button className="btn-ghost" onClick={downloadMcp} disabled={mcpBusy}>
+            <Icon.Download /> {mcpBusy ? "Downloading…" : mcpMissing ? "Repair / choose folder…" : "Download MCP server"}
+          </button>
+        )}
+        {(mcpPath || mcpReady) && (
           <div className="mcp-setup-box">
             <label>
               <span className="lbl">Downloaded folder</span>
@@ -4909,6 +4932,11 @@ function SettingsView() {
               </button>
               <button className="btn-ghost btn-sm" onClick={copyMcpInstall}>Copy install command</button>
               <button className="btn-ghost btn-sm" onClick={copyMcpConfig}>Copy MCP config</button>
+              {mcpReady && (
+                <button className="btn-ghost btn-sm" onClick={downloadMcp} disabled={mcpBusy}>
+                  <Icon.Refresh /> {mcpBusy ? "Downloading…" : "Change / repair…"}
+                </button>
+              )}
             </div>
           </div>
         )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4774,6 +4774,16 @@ function SettingsView() {
     } catch (e) { toast.err("MCP download failed: " + String(e)); }
     finally { setMcpBusy(false); }
   };
+  const useExistingMcp = async () => {
+    const dir = await open({ directory: true, title: "Select an existing ShardX MCP folder" });
+    if (typeof dir !== "string") return;
+    try {
+      const status = await invoke<McpStatus>("mcp_set_path", { dir });
+      applyMcpStatus(status);
+      setS((cur) => ({ ...cur, mcp_path: status.path }));
+      toast.ok(`Using MCP at ${status.path}`);
+    } catch (e) { toast.err(String(e)); }
+  };
   const mcpIndexPath = (dir: string) => {
     const clean = dir.replace(/[\\/]+$/, "");
     return `${clean}${clean.includes("\\") ? "\\" : "/"}index.js`;
@@ -4916,9 +4926,14 @@ function SettingsView() {
           <li>Set <code>SHARDX_TOKEN</code> in your user environment, restart your MCP client, then register <code>index.js</code>.</li>
         </ol>
         {!mcpReady && (
-          <button className="btn-ghost" onClick={downloadMcp} disabled={mcpBusy}>
-            <Icon.Download /> {mcpBusy ? "Downloading…" : mcpMissing ? "Repair / choose folder…" : "Download MCP server"}
-          </button>
+          <div className="row-inline" style={{ gap: 10 }}>
+            <button className="btn-ghost" onClick={downloadMcp} disabled={mcpBusy}>
+              <Icon.Download /> {mcpBusy ? "Downloading…" : mcpMissing ? "Repair / choose folder…" : "Download MCP server"}
+            </button>
+            <button className="btn-ghost" onClick={useExistingMcp} disabled={mcpBusy}>
+              Use existing folder…
+            </button>
+          </div>
         )}
         {(mcpPath || mcpReady) && (
           <div className="mcp-setup-box">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4762,7 +4762,12 @@ function SettingsView() {
   useEffect(() => { refreshMcp(); }, []);
   // Download MCP server source; user manages install + client setup.
   const downloadMcp = async () => {
-    const dir = await open({ directory: true, title: "Where to download the MCP server" });
+    const dir = await open({
+      directory: true,
+      title: mcpStatus?.installed
+        ? "Choose an MCP folder to repair, or a parent folder to download into"
+        : "Where to download the MCP server",
+    });
     if (typeof dir !== "string") return;
     setMcpBusy(true);
     try {
@@ -4777,12 +4782,14 @@ function SettingsView() {
   const useExistingMcp = async () => {
     const dir = await open({ directory: true, title: "Select an existing ShardX MCP folder" });
     if (typeof dir !== "string") return;
+    setMcpBusy(true);
     try {
       const status = await invoke<McpStatus>("mcp_set_path", { dir });
       applyMcpStatus(status);
       setS((cur) => ({ ...cur, mcp_path: status.path }));
       toast.ok(`Using MCP at ${status.path}`);
     } catch (e) { toast.err(String(e)); }
+    finally { setMcpBusy(false); }
   };
   const mcpIndexPath = (dir: string) => {
     const clean = dir.replace(/[\\/]+$/, "");
@@ -4921,7 +4928,7 @@ function SettingsView() {
           <span>{mcpStatus?.message ?? "Checking MCP status…"}</span>
         </div>
         <ol className="settings-steps">
-          <li>{mcpReady ? "MCP files are already downloaded." : "Download the server once."}</li>
+          <li>{mcpReady ? "MCP files are already downloaded; use existing folder to switch without re-downloading." : "Download the server once."}</li>
           <li>Run <code>npm install</code> inside the downloaded folder.</li>
           <li>Set <code>SHARDX_TOKEN</code> in your user environment, restart your MCP client, then register <code>index.js</code>.</li>
         </ol>
@@ -4948,9 +4955,24 @@ function SettingsView() {
               <button className="btn-ghost btn-sm" onClick={copyMcpInstall}>Copy install command</button>
               <button className="btn-ghost btn-sm" onClick={copyMcpConfig}>Copy MCP config</button>
               {mcpReady && (
-                <button className="btn-ghost btn-sm" onClick={downloadMcp} disabled={mcpBusy}>
-                  <Icon.Refresh /> {mcpBusy ? "Downloading…" : "Change / repair…"}
-                </button>
+                <>
+                  <button
+                    className="btn-ghost btn-sm"
+                    onClick={useExistingMcp}
+                    disabled={mcpBusy}
+                    title="Point Settings at another already-downloaded MCP folder"
+                  >
+                    Use existing folder…
+                  </button>
+                  <button
+                    className="btn-ghost btn-sm"
+                    onClick={downloadMcp}
+                    disabled={mcpBusy}
+                    title="Download a fresh copy or repair the selected MCP folder in place"
+                  >
+                    <Icon.Refresh /> {mcpBusy ? "Downloading…" : "Download / repair…"}
+                  </button>
+                </>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- keep the downloaded MCP folder visible in Settings after download
- add setup steps for npm install, MCP registration, and SHARDX_TOKEN usage
- add buttons to open the downloaded folder, copy the install command, and copy a token-free MCP config snippet

## Validation
- `npm run build`
- `git diff --check -- src/App.tsx src/App.css`

## Notes
- UI-only change; no backend/API/browser engine/fingerprint behavior changed.
- Config snippet intentionally omits token values and relies on SHARDX_TOKEN from the environment.