### PR TITLE
Add DevTools CDP handoff helpers

### DIFF
--- a/docs/CODEX_DEVTOOLS_QA.md
+++ b/docs/CODEX_DEVTOOLS_QA.md
@@ -1,0 +1,60 @@
+# Codex ShardBrowser + Chrome DevTools QA
+
+Use this when a Codex task needs both a ShardX profile and DevTools-grade
+console/network/performance evidence.
+
+## Current attach audit
+
+- `shardbrowser` MCP starts the chosen ShardX profile and returns CDP data with
+  `devtools_context`.
+- `chrome-devtools-mcp@1.5.0` supports `--browserUrl` and `--wsEndpoint`, but
+  the exposed Codex tools do not include a runtime attach/connect call. Pick the
+  browser in the MCP client config before startup.
+- Keep this integration at the MCP/client layer. Do not wire
+  `chrome_devtools` into Launcher core or browser fingerprint code.
+
+## Workflow
+
+1. Resolve the profile:
+   ```text
+   mcp__shardbrowser.list_profiles
+   ```
+2. Open the target page in the intended profile:
+   ```text
+   mcp__shardbrowser.browser_navigate({
+     "profile_id": "<profile-id>",
+     "url": "https://example.com/"
+   })
+   ```
+3. Get the live CDP handoff:
+   ```text
+   mcp__shardbrowser.devtools_context({
+     "profile_id": "<profile-id>"
+   })
+   ```
+   If the profile is already running without CDP, stop and restart it through
+   ShardBrowser MCP or the Automation API; a running browser process cannot get
+   a CDP port retrofitted in place.
+4. For ShardX-only checks, continue with `shardbrowser` tools:
+   `browser_aria_snapshot`, `browser_screenshot`, `browser_capture_start`,
+   `browser_capture_stop`, and `browser_set_network_conditions`.
+5. For Chrome DevTools MCP checks against the ShardX page, register a second
+   MCP entry from the returned CDP URL, then restart Codex:
+   ```powershell
+   codex mcp add shardbrowser-devtools -- cmd /c npx -y chrome-devtools-mcp@1.5.0 --browserUrl http://127.0.0.1:<cdp-port> --no-usage-statistics --no-performance-crux --redactNetworkHeaders
+   ```
+6. After restart, use the configured DevTools namespace for `take_snapshot`,
+   `list_console_messages`, `list_network_requests`, `performance_start_trace`,
+   `performance_stop_trace`, and `lighthouse_audit`.
+
+## End-to-end prompt goal
+
+```text
+Use ShardBrowser MCP to open the requested URL in the exact profile, call
+devtools_context, and report the CDP http_url plus current page title/url. If
+chrome_devtools is still configured as isolated Chrome, do not claim it audited
+the ShardX profile; either run ShardBrowser-native screenshot, a11y, and
+network checks, or give the exact Codex MCP add/repair command needed to
+register chrome-devtools-mcp with the returned --browserUrl. Never print tokens,
+cookies, fingerprint payloads, or proxy credentials.
+```

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -57,7 +57,7 @@ async function cdpEndpoint(profileId, { autostart = true, headless = false } = {
   }
   const cdp = entry?.cdp;
   if (!cdp?.http_url) {
-    throw new Error(`profile ${profileId} is not running with CDP (start it first)`);
+    throw new Error(`profile ${profileId} is not running with CDP (stop/restart it through MCP or the Automation API to enable DevTools)`);
   }
   return cdp;
 }
@@ -166,6 +166,42 @@ const text = (v) => ({
   content: [{ type: "text", text: typeof v === "string" ? v : JSON.stringify(v, null, 2) }],
 });
 
+async function resolveProfile({ profile_id, profile_query, exact = false }) {
+  if (profile_id) return { id: profile_id };
+  const q = (profile_query || "").trim().toLowerCase();
+  if (!q) throw new Error("provide profile_id or profile_query");
+  const matches = (await api("/profiles")).filter((profile) => {
+    const id = String(profile.id || "");
+    const name = String(profile.name || "").toLowerCase();
+    return id === profile_query || (exact ? name === q : name.includes(q));
+  });
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly 1 profile match, got ${matches.length}`);
+  }
+  return matches[0];
+}
+
+async function cdpJson(cdp, path) {
+  const res = await fetch(new URL(path, cdp.http_url).href);
+  const data = await res.json().catch(() => null);
+  if (!res.ok) throw new Error(`CDP ${path} → HTTP ${res.status}`);
+  return data;
+}
+
+function targetSummary(cdp, target) {
+  return {
+    id: target.id,
+    type: target.type,
+    title: target.title || "",
+    url: target.url || "",
+    attached: !!target.attached,
+    web_socket_debugger_url: target.webSocketDebuggerUrl || null,
+    devtools_frontend_url: target.devtoolsFrontendUrl
+      ? new URL(target.devtoolsFrontendUrl, cdp.http_url).href
+      : null,
+  };
+}
+
 const server = new McpServer({ name: "shardx", version: "0.1.0" });
 
 // ================= API tools =================
@@ -175,6 +211,42 @@ server.tool(
   "List persistent profiles with their running state and CDP endpoint.",
   {},
   async () => text(await api("/profiles")),
+);
+
+server.tool(
+  "devtools_context",
+  "Resolve/start a profile and return its CDP endpoint plus /json/list page targets for Chrome DevTools handoff.",
+  {
+    profile_id: z.string().optional(),
+    profile_query: z.string().optional(),
+    exact: z.boolean().optional(),
+    headless: z.boolean().optional(),
+  },
+  async ({ profile_id, profile_query, exact, headless }) => {
+    const profile = await resolveProfile({ profile_id, profile_query, exact });
+    const cdp = await cdpEndpoint(profile.id, { autostart: true, headless: !!headless });
+    const rawTargets = await cdpJson(cdp, "/json/list");
+    const targets = (Array.isArray(rawTargets) ? rawTargets : [])
+      .filter((t) => t.type === "page")
+      .map((t) => targetSummary(cdp, t));
+    const currentPage = activePage.get(profile.id);
+    let current = targets.find((t) => t.url && !t.url.startsWith("devtools://")) || null;
+    if (currentPage && !currentPage.isClosed()) {
+      const url = currentPage.url();
+      const target = targets.find((t) => t.url === url);
+      current = {
+        ...(target || {}),
+        url,
+        title: await currentPage.title().catch(() => target?.title || ""),
+      };
+    }
+    return text({
+      profile: { id: profile.id, name: profile.name, running: true },
+      cdp,
+      targets,
+      current,
+    });
+  },
 );
 
 server.tool(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -832,6 +832,91 @@ fn process_list() -> Vec<process::RunningProfile> {
     process::Tracker::shared().running()
 }
 
+fn devtools_frontend_url(cdp_http_url: &str, path: &str) -> String {
+    if path.starts_with("http://") || path.starts_with("https://") || path.starts_with("devtools://") {
+        return path.to_string();
+    }
+    format!(
+        "{}{}{}",
+        cdp_http_url.trim_end_matches('/'),
+        if path.starts_with('/') { "" } else { "/" },
+        path
+    )
+}
+
+fn devtools_target_summary(cdp: &process::CdpInfo, target: &Value) -> Value {
+    let frontend = target
+        .get("devtoolsFrontendUrl")
+        .and_then(Value::as_str)
+        .map(|path| devtools_frontend_url(&cdp.http_url, path));
+    serde_json::json!({
+        "id": target.get("id").and_then(Value::as_str).unwrap_or(""),
+        "type": target.get("type").and_then(Value::as_str).unwrap_or(""),
+        "title": target.get("title").and_then(Value::as_str).unwrap_or(""),
+        "url": target.get("url").and_then(Value::as_str).unwrap_or(""),
+        "attached": target.get("attached").and_then(Value::as_bool).unwrap_or(false),
+        "web_socket_debugger_url": target.get("webSocketDebuggerUrl").and_then(Value::as_str),
+        "devtools_frontend_url": frontend,
+    })
+}
+
+#[cfg(test)]
+mod devtools_tests {
+    use super::devtools_frontend_url;
+
+    #[test]
+    fn joins_relative_frontend_url() {
+        assert_eq!(
+            devtools_frontend_url("http://127.0.0.1:9222", "/devtools/inspector.html?ws=x"),
+            "http://127.0.0.1:9222/devtools/inspector.html?ws=x"
+        );
+    }
+}
+
+#[tauri::command]
+async fn devtools_context(profile_id: String) -> Result<Value, String> {
+    let cdp = process::Tracker::shared()
+        .cdp(&profile_id)
+        .ok_or_else(|| "Profile is running without CDP. Start it through Automation API or MCP to enable DevTools.".to_string())?;
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let targets: Value = client
+        .get(format!("{}/json/list", cdp.http_url.trim_end_matches('/')))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .error_for_status()
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())?;
+    let targets: Vec<Value> = match targets.as_array() {
+        Some(targets) => targets
+            .iter()
+            .filter(|target| target.get("type").and_then(Value::as_str) == Some("page"))
+            .map(|target| devtools_target_summary(&cdp, target))
+            .collect(),
+        None => Vec::new(),
+    };
+    let current = targets
+        .iter()
+        .find(|target| {
+            target
+                .get("url")
+                .and_then(Value::as_str)
+                .is_some_and(|url| !url.is_empty() && !url.starts_with("devtools://"))
+        })
+        .cloned();
+    Ok(serde_json::json!({
+        "profile_id": profile_id,
+        "cdp": cdp,
+        "targets": targets,
+        "current": current,
+    }))
+}
+
 #[tauri::command]
 async fn process_kill(profile_id: String) -> Result<bool, String> {
     process::Tracker::shared()
@@ -1548,6 +1633,7 @@ pub fn run() {
             fingerprint_dir,
             read_text_file,
             process_list,
+            devtools_context,
             process_kill,
             proxy_list,
             proxy_save,


### PR DESCRIPTION
## Summary
- add `devtools_context` MCP helper that returns CDP HTTP/WebSocket URLs plus `/json/list` page targets for a profile
- show `DevTools/CDP ready` on running profile rows and add copy actions for CDP HTTP / DevTools inspect URLs
- document the Codex + Chrome DevTools MCP handoff workflow

## Notes
- no browser engine, fingerprint, profile isolation, token, cookie, or proxy credential behavior changes
- `chrome_devtools` attach stays at MCP client startup/configuration layer; Launcher core only exposes/copies existing CDP URLs

## Tests
- `node --check mcp/index.js`
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`