### PR TITLE
Fix Python SDK UTF-8 profile JSON IO

### DIFF
--- a/sdks/python/shardx/__init__.py
+++ b/sdks/python/shardx/__init__.py
@@ -126,14 +126,14 @@ class ShardX:
         mutating a reopened profile (e.g. `set_noise`) to keep changes."""
         path = self._profile_json_path(profile.id)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(profile.config, indent=2))
+        path.write_text(json.dumps(profile.config, indent=2), encoding="utf-8")
 
     def open_profile(self, id: str) -> Profile:
         """Reopen a previously created profile by id (same fingerprint + state)."""
         path = self._profile_json_path(id)
         if not path.exists():
             raise FileNotFoundError(f"saved profile {id!r} not found")
-        return Profile(json.loads(path.read_text()), id=id)
+        return Profile(json.loads(path.read_text(encoding="utf-8")), id=id)
 
     def list_saved_profiles(self) -> list[str]:
         """Ids of every saved profile, sorted."""

--- a/sdks/python/shardx/browser.py
+++ b/sdks/python/shardx/browser.py
@@ -157,7 +157,7 @@ class Browser:
         )
         apply_noise_seeds(profile.config, profile.id)
         fp_file = udd / "fingerprint.json"
-        fp_file.write_text(json.dumps(profile.config))
+        fp_file.write_text(json.dumps(profile.config), encoding="utf-8")
 
         argv: list[str] = [
             str(self.runtime.binary_path),
@@ -233,7 +233,7 @@ def _read_cdp_endpoint(udd: Path, timeout: float) -> Optional[str]:
     while time.monotonic() < deadline:
         if marker.exists():
             try:
-                port = int(marker.read_text().splitlines()[0].strip())
+                port = int(marker.read_text(encoding="utf-8").splitlines()[0].strip())
                 with urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=2.0) as r:
                     data = json.loads(r.read())
                     return data.get("webSocketDebuggerUrl")

--- a/sdks/python/shardx/profile.py
+++ b/sdks/python/shardx/profile.py
@@ -26,7 +26,7 @@ class Profile:
     @classmethod
     def from_file(cls, path: str | Path) -> "Profile":
         p = Path(path)
-        cfg = json.loads(p.read_text())
+        cfg = json.loads(p.read_text(encoding="utf-8"))
         return cls(cfg, id=p.stem)
 
     def with_override(self, **overrides) -> "Profile":

--- a/sdks/python/shardx/runtime.py
+++ b/sdks/python/shardx/runtime.py
@@ -262,7 +262,7 @@ class Runtime:
         """Build stamp on disk: `<engine>/shardx-build` when the archive ships
         one, else what was recorded at install time."""
         try:
-            stamp = (self.root / self._spec.binary_subpath[0] / "shardx-build").read_text().strip()
+            stamp = (self.root / self._spec.binary_subpath[0] / "shardx-build").read_text(encoding="utf-8").strip()
             if stamp:
                 return stamp
         except OSError:
@@ -280,12 +280,12 @@ class Runtime:
 
     def _load_manifest(self) -> dict:
         try:
-            return json.loads(self.manifest_path.read_text())
+            return json.loads(self.manifest_path.read_text(encoding="utf-8"))
         except Exception:
             return {}
 
     def _save_manifest(self, m: dict) -> None:
-        self.manifest_path.write_text(json.dumps(m, indent=2))
+        self.manifest_path.write_text(json.dumps(m, indent=2), encoding="utf-8")
 
     # ---- install ----
 


### PR DESCRIPTION
## Summary
- Read bundled fingerprint/profile JSON with explicit UTF-8 in the Python SDK.
- Write saved profile JSON with explicit UTF-8 for round-trip consistency.

Fixes #17.

## Tests
- `python -m compileall -q sdks/python/shardx`
- Local UTF-8 `Profile.from_file` smoke with a byte sequence that fails on Windows cp1251 defaults.