### PR TITLE
Allow canvas noise overrides for temporary profiles

### DIFF
--- a/mcp/index.js
+++ b/mcp/index.js
@@ -156,6 +156,7 @@ server.tool(
     fingerprint_id: z.string().optional(),
     platform: z.enum(["Windows", "macOS", "Linux"]).optional(),
     proxy: z.string().optional(),
+    noise: z.record(z.any()).optional(),
     name: z.string().optional(),
     folder: z.string().optional(),
   },

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -862,6 +862,11 @@ components:
         proxy:
           type: string
           description: Inline proxy string (not saved to the store).
+        noise:
+          allOf: [{ $ref: "#/components/schemas/NoisePrefs" }]
+          description: |
+            Per-vector noise override for the temporary profile; seed 0 is
+            derived from the temporary profile id.
         name: { type: string }
         folder: { type: string }
 

--- a/scripts/smoke-canvas-noise.mjs
+++ b/scripts/smoke-canvas-noise.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+const API = (process.env.SHARDX_API || "http://127.0.0.1:40325").replace(/\/+$/, "");
+const TOKEN = process.env.SHARDX_TOKEN || "";
+
+if (typeof WebSocket !== "function") {
+  throw new Error("Node.js with global WebSocket is required.");
+}
+
+async function api(path, { method = "GET", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
+      ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  const data = text ? JSON.parse(text) : null;
+  if (!res.ok) throw new Error(`${method} ${path} -> ${data?.error || res.status}`);
+  return data;
+}
+
+function openWs(url) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.addEventListener("open", () => resolve(ws), { once: true });
+    ws.addEventListener("error", () => reject(new Error(`WebSocket failed: ${url}`)), { once: true });
+  });
+}
+
+let nextId = 1;
+function cdp(ws, method, params = {}) {
+  const id = nextId++;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${method} timed out`)), 10_000);
+    const onMessage = (event) => {
+      const msg = JSON.parse(event.data);
+      if (msg.id !== id) return;
+      clearTimeout(timer);
+      ws.removeEventListener("message", onMessage);
+      if (msg.error) reject(new Error(`${method}: ${msg.error.message}`));
+      else resolve(msg.result || {});
+    };
+    ws.addEventListener("message", onMessage);
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+}
+
+async function canvasHash(page) {
+  const expression = `
+    (async () => {
+      const c = document.createElement("canvas");
+      c.width = 240; c.height = 80;
+      const ctx = c.getContext("2d");
+      ctx.textBaseline = "top";
+      ctx.font = "16px Arial";
+      ctx.fillStyle = "#f60";
+      ctx.fillRect(100, 1, 62, 20);
+      ctx.fillStyle = "#069";
+      ctx.fillText("ShardX canvas smoke", 2, 15);
+      ctx.strokeStyle = "rgba(120,120,0,0.7)";
+      ctx.beginPath(); ctx.arc(70, 50, 30, 0, Math.PI * 2); ctx.stroke();
+      const bytes = new TextEncoder().encode(c.toDataURL());
+      const hash = await crypto.subtle.digest("SHA-256", bytes);
+      return [...new Uint8Array(hash)].map((b) => b.toString(16).padStart(2, "0")).join("");
+    })()
+  `;
+  const out = await cdp(page, "Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  if (out.exceptionDetails) throw new Error("Canvas evaluation failed");
+  return out.result.value;
+}
+
+async function hashForTempProfile(label) {
+  const created = await api("/profiles/temporary", {
+    method: "POST",
+    body: {
+      name: `canvas-smoke-${label}-${Date.now()}`,
+      noise: { canvas: { enabled: true, seed: 0 } },
+    },
+  });
+  const started = await api(`/profiles/${created.id}/start`, {
+    method: "POST",
+    body: { headless: true },
+  });
+  const cdpInfo = started.cdp;
+  if (!cdpInfo?.http_url || !cdpInfo?.web_socket_debugger_url) {
+    throw new Error("Profile started without a CDP endpoint");
+  }
+
+  const browser = await openWs(cdpInfo.web_socket_debugger_url);
+  let page;
+  try {
+    const { targetId } = await cdp(browser, "Target.createTarget", { url: "about:blank" });
+    const targets = await (await fetch(`${cdpInfo.http_url}/json/list`)).json();
+    const target = targets.find((t) => t.id === targetId) || targets.find((t) => t.type === "page");
+    if (!target?.webSocketDebuggerUrl) throw new Error("No page target WebSocket URL");
+    page = await openWs(target.webSocketDebuggerUrl);
+    return { id: created.id, hash: await canvasHash(page) };
+  } finally {
+    try { page?.close(); } catch {}
+    try { browser.close(); } catch {}
+    await api(`/profiles/${created.id}/stop`, { method: "POST" }).catch(() => {});
+  }
+}
+
+const a = await hashForTempProfile("a");
+const b = await hashForTempProfile("b");
+
+console.log(JSON.stringify({ a: a.hash, b: b.hash, distinct: a.hash !== b.hash }, null, 2));
+if (a.hash === b.hash) {
+  throw new Error("Canvas hashes are identical; temporary profile canvas noise is not varying.");
+}

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -12,7 +12,7 @@ use axum::{
     Json, Router,
 };
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 
 // ---- HS256 secret (process-global so live rotation invalidates old tokens) ----
 
@@ -253,8 +253,51 @@ struct TempReq {
     platform: Option<String>,
     /// Inline proxy (not stored).
     proxy: Option<String>,
+    /// Optional per-vector noise override, e.g.
+    /// `{ "canvas": { "enabled": true, "seed": 0 } }`.
+    noise: Option<Value>,
     name: Option<String>,
     folder: Option<String>,
+}
+
+fn apply_temp_noise_override(
+    cfg: &mut Map<String, Value>,
+    noise: Option<Value>,
+) -> Result<(), String> {
+    let Some(noise) = noise else {
+        return Ok(());
+    };
+    if !noise.is_object() {
+        return Err("`noise` must be an object".into());
+    }
+    cfg.insert("noise".into(), noise);
+    Ok(())
+}
+
+#[cfg(test)]
+mod temp_profile_tests {
+    use super::apply_temp_noise_override;
+    use serde_json::{json, Map, Value};
+
+    #[test]
+    fn temporary_profile_accepts_noise_override() {
+        let mut cfg = Map::<String, Value>::new();
+
+        apply_temp_noise_override(
+            &mut cfg,
+            Some(json!({ "canvas": { "enabled": true, "seed": 0 } })),
+        )
+        .unwrap();
+
+        assert_eq!(cfg["noise"]["canvas"]["enabled"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn temporary_profile_rejects_non_object_noise() {
+        let mut cfg = Map::<String, Value>::new();
+
+        assert!(apply_temp_noise_override(&mut cfg, Some(json!(true))).is_err());
+    }
 }
 
 /// Temporary profile (hidden, auto-deleted on close); pair with /start.
@@ -269,6 +312,8 @@ async fn create_temporary(Json(body): Json<TempReq>) -> ApiResult {
     if let Some(n) = body.name.as_ref() {
         cfg.insert("name".into(), json!(n));
     }
+    apply_temp_noise_override(&mut cfg, body.noise)
+        .map_err(|e| err(StatusCode::BAD_REQUEST, e))?;
     let mut meta = json!({ "id": "", "folder": body.folder.unwrap_or_default(), "temporary": true });
     if let Some(pstr) = body.proxy.as_ref() {
         let entry = crate::proxy::parse_single(pstr)


### PR DESCRIPTION
## Summary
- Accept a `noise` object on `POST /profiles/temporary` instead of silently ignoring it.
- Keep `seed: 0` behavior so temporary profile noise is derived from the generated profile id.
- Document the field in OpenAPI and expose it through the MCP temporary-profile helper.
- Add a CDP smoke script that creates two temporary canvas-noise profiles and fails if their canvas hashes match.

Fixes #11.

## Tests
- `cargo test --manifest-path src-tauri\Cargo.toml --lib temporary_profile_`
- `node --check mcp\index.js`
- `node --check scripts\smoke-canvas-noise.mjs`
- `npm run build`
- `git diff --check`

Note: the live smoke script is intended to run after building/installing this branch, with `SHARDX_TOKEN` available and the Launcher API running.