### PR TITLE
feat(ui): add proxy during profile creation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1075,6 +1075,22 @@ textarea { resize: vertical; min-height: 60px; line-height: 1.5; }
 .inline-editor .cs-opt { font-size: 13.5px; padding: 9px 11px; }
 .inline-editor .seg-btn { font-size: 12.5px; padding: 8px 10px; }
 .inline-editor .tri-btn { font-size: 12px; padding: 7px 0; }
+.inline-proxy-details {
+  padding: 9px 10px;
+  border: 1px solid var(--bd-1);
+  border-radius: var(--radius);
+  background: var(--bg-1);
+}
+.inline-proxy-details summary {
+  width: fit-content;
+  color: var(--tx-2);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.inline-proxy-details[open] summary { color: var(--tx-1); }
+.inline-proxy-body { display: flex; flex-direction: column; gap: 6px; margin-top: 9px; }
+.inline-proxy-error { color: var(--err); font-size: 12px; line-height: 1.4; overflow-wrap: anywhere; }
 
 .form-row {
   display: grid;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1013,6 +1013,10 @@ function BrowsersView() {
   const [folder, setFolder] = useState("all");
   const [expanded, setExpanded] = useState<string | null>(null);
   const [draft, setDraft] = useState<ProfileForm | null>(null);
+  const [inlineProxyText, setInlineProxyText] = useState("");
+  const [inlineProxyError, setInlineProxyError] = useState<string | null>(null);
+  const [profileSaveBusy, setProfileSaveBusy] = useState(false);
+  const profileSaveBusyRef = useRef(false);
   // Value = epoch ms at which the engine was first observed running. Used
   // both as a truthy flag (any number = running) and as the anchor for the
   // ticking uptime display in the Status column.
@@ -1375,23 +1379,53 @@ function BrowsersView() {
   };
 
   const expand = async (id: string) => {
+    if (profileSaveBusy) return;
     if (expanded === id) { setExpanded(null); setDraft(null); return; }
     const stored = await invoke<any>("profile_get", { id });
+    setInlineProxyText("");
+    setInlineProxyError(null);
     setDraft(fromStored(stored));
     setExpanded(id);
   };
 
   const newProfile = async () => {
+    if (profileSaveBusy) return;
+    setInlineProxyText("");
+    setInlineProxyError(null);
     setDraft(defaultForm());
     setExpanded("__new__");
   };
 
   const saveDraft = async () => {
-    if (!draft) return;
+    if (!draft || profileSaveBusyRef.current) return;
+    const creating = !draft.id;
+    const hasInlineProxy = creating && inlineProxyText.trim().length > 0;
+    let createdProfileId: string | null = null;
+    let createdProxyId: string | null = null;
+    profileSaveBusyRef.current = true;
+    setProfileSaveBusy(true);
+    setInlineProxyError(null);
     try {
+      let proxyId = draft.proxy_id;
+      if (hasInlineProxy) {
+        const parsed = await invoke<ProxyEntry[]>("proxy_bulk_parse", {
+          text: inlineProxyText.trim(),
+          kind: "socks5",
+        });
+        if (parsed.length !== 1) {
+          setInlineProxyError("Enter exactly one valid proxy using a supported host/port format.");
+          return;
+        }
+        const savedProxy = await invoke<ProxyEntry>("proxy_save", { entry: parsed[0] });
+        createdProxyId = savedProxy.id;
+        proxyId = savedProxy.id;
+      }
       const fp = fingerprints.find((g) => g.id === draft.gpu_preset_id) ?? null;
-      const saved = await invoke<ProfileMeta>("profile_save", { payload: toStored(draft, fp) });
-      await invoke("profile_bind_proxy", { profileId: saved.id, proxyId: draft.proxy_id });
+      const saved = await invoke<ProfileMeta>("profile_save", {
+        payload: toStored({ ...draft, proxy_id: proxyId }, fp),
+      });
+      if (creating) createdProfileId = saved.id;
+      await invoke("profile_bind_proxy", { profileId: saved.id, proxyId });
       // A profile created while a folder tab is active should land in that
       // folder (otherwise it pops into "All" and the user has to drag it
       // back themselves).  `__new__` test scopes this to creations only —
@@ -1402,9 +1436,31 @@ function BrowsersView() {
       }
       setExpanded(null);
       setDraft(null);
+      setInlineProxyText("");
       reload();
       toast.ok(draft.id ? "Profile saved" : `Created "${saved.name}"`);
-    } catch (e) { toast.err(String(e)); }
+    } catch (e) {
+      let profileRolledBack = createdProfileId === null;
+      if (createdProfileId) {
+        try {
+          await invoke("profile_delete", { id: createdProfileId });
+          profileRolledBack = true;
+        } catch {
+          profileRolledBack = false;
+        }
+      }
+      if (createdProxyId && profileRolledBack) {
+        try { await invoke("proxy_delete", { id: createdProxyId }); } catch { /* Preserve the original failure. */ }
+      }
+      const message = hasInlineProxy
+        ? "The proxy or profile could not be saved. Check the proxy format and try again."
+        : String(e);
+      if (hasInlineProxy) setInlineProxyError(message);
+      toast.err(message);
+    } finally {
+      profileSaveBusyRef.current = false;
+      setProfileSaveBusy(false);
+    }
   };
 
   const toggleSel = (id: string) => {
@@ -1600,8 +1656,20 @@ function BrowsersView() {
               setDraft={setDraft}
               proxies={proxies}
               fingerprints={fingerprints}
+              inlineProxyText={inlineProxyText}
+              inlineProxyError={inlineProxyError}
+              saving={profileSaveBusy}
+              onInlineProxyChange={(value) => {
+                setInlineProxyText(value);
+                setInlineProxyError(null);
+              }}
               onSave={saveDraft}
-              onCancel={() => { setExpanded(null); setDraft(null); }}
+              onCancel={() => {
+                setExpanded(null);
+                setDraft(null);
+                setInlineProxyText("");
+                setInlineProxyError(null);
+              }}
             />
           </div>
         )}
@@ -1729,7 +1797,10 @@ function BrowsersView() {
                   setDraft={setDraft}
                   proxies={proxies}
                   fingerprints={fingerprints}
-
+                  inlineProxyText=""
+                  inlineProxyError={null}
+                  saving={profileSaveBusy}
+                  onInlineProxyChange={() => {}}
                   onSave={saveDraft}
                   onCancel={() => { setExpanded(null); setDraft(null); }}
                 />
@@ -1851,13 +1922,18 @@ const OS_OPTIONS: { id: OsPlatform; label: string }[] = [
 ];
 
 function InlineEditor({
-  draft, setDraft, proxies, fingerprints, onSave, onCancel,
+  draft, setDraft, proxies, fingerprints, inlineProxyText, inlineProxyError,
+  saving, onInlineProxyChange, onSave, onCancel,
 }: {
   draft: ProfileForm;
   setDraft: (f: ProfileForm) => void;
   proxies: ProxyEntry[];
   fingerprints: FingerprintEntry[];
-  onSave: () => void;
+  inlineProxyText: string;
+  inlineProxyError: string | null;
+  saving: boolean;
+  onInlineProxyChange: (value: string) => void;
+  onSave: () => void | Promise<void>;
   onCancel: () => void;
 }) {
   const f = draft;
@@ -1975,7 +2051,10 @@ function InlineEditor({
             <span className="lbl">Proxy</span>
             <CSSelect
               value={f.proxy_id ?? ""}
-              onChange={(v) => u("proxy_id", v ? v : null)}
+              onChange={(v) => {
+                onInlineProxyChange("");
+                u("proxy_id", v ? v : null);
+              }}
               options={[
                 { value: "", label: "— direct connection —" },
                 ...proxies.map((px) => ({
@@ -1985,6 +2064,38 @@ function InlineEditor({
               ]}
             />
           </label>
+          {!f.id && (
+            <details className="inline-proxy-details">
+              <summary>Enter a new proxy</summary>
+              <div className="inline-proxy-body">
+                <label htmlFor="inline-proxy-address">
+                  <span className="lbl">Proxy address</span>
+                  <input
+                    id="inline-proxy-address"
+                    type="password"
+                    autoComplete="off"
+                    spellCheck={false}
+                    value={inlineProxyText}
+                    aria-describedby={inlineProxyError ? "inline-proxy-help inline-proxy-error" : "inline-proxy-help"}
+                    aria-invalid={!!inlineProxyError}
+                    placeholder="socks5://user:pass@host:port"
+                    onChange={(e) => {
+                      onInlineProxyChange(e.target.value);
+                      if (e.target.value) u("proxy_id", null);
+                    }}
+                  />
+                </label>
+                <span id="inline-proxy-help" className="muted small">
+                  One proxy only. Supports SOCKS5, HTTP, HTTPS, host:port, and the existing bulk-import formats.
+                </span>
+                {inlineProxyError && (
+                  <span id="inline-proxy-error" className="inline-proxy-error" role="alert">
+                    {inlineProxyError}
+                  </span>
+                )}
+              </div>
+            </details>
+          )}
         </div>
 
         {/* ----- col 2: locale + noise ----- */}
@@ -2090,9 +2201,9 @@ function InlineEditor({
         </div>
       </div>
       <div className="ie-foot">
-        <button className="btn-ghost" onClick={onCancel}>Cancel</button>
-        <button className="btn-primary" onClick={onSave}>
-          <ShardMini /> {f.id ? "Save changes" : "Create profile"}
+        <button className="btn-ghost" onClick={onCancel} disabled={saving}>Cancel</button>
+        <button className="btn-primary" onClick={onSave} disabled={saving} aria-busy={saving}>
+          <ShardMini /> {saving ? "Saving…" : f.id ? "Save changes" : "Create profile"}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add an optional inline proxy field to the new-profile editor
- reuse the existing proxy parser/save/bind commands
- prevent duplicate submits and roll back newly created records when profile setup fails

## Scope
- frontend only (`src/App.tsx`, `src/App.css`)
- no browser engine, fingerprint, or profile-isolation changes
- no new dependencies

## Validation
- `npm ci`
- `npm run build` (TypeScript + Vite 5.4.21 production build)
- `git diff --check`

Closes #27